### PR TITLE
add route for sso session idp

### DIFF
--- a/src/__tests__/components/__snapshots__/App.test.js.snap
+++ b/src/__tests__/components/__snapshots__/App.test.js.snap
@@ -109,6 +109,10 @@ ShallowWrapper {
           />
           <Route
             component={[Function]}
+            path="/ssoLogin/:loginIdp"
+          />
+          <Route
+            component={[Function]}
             path="/login"
           />
           <Route
@@ -212,6 +216,10 @@ ShallowWrapper {
                   "verfied": false,
                 }
               }
+            />,
+            <Route
+              component={[Function]}
+              path="/ssoLogin/:loginIdp"
             />,
             <Route
               component={[Function]}
@@ -343,6 +351,18 @@ ShallowWrapper {
             "nodeType": "class",
             "props": Object {
               "component": [Function],
+              "path": "/ssoLogin/:loginIdp",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "component": [Function],
               "path": "/login",
             },
             "ref": null,
@@ -462,6 +482,10 @@ ShallowWrapper {
             />
             <Route
               component={[Function]}
+              path="/ssoLogin/:loginIdp"
+            />
+            <Route
+              component={[Function]}
               path="/login"
             />
             <Route
@@ -565,6 +589,10 @@ ShallowWrapper {
                     "verfied": false,
                   }
                 }
+              />,
+              <Route
+                component={[Function]}
+                path="/ssoLogin/:loginIdp"
               />,
               <Route
                 component={[Function]}
@@ -685,6 +713,18 @@ ShallowWrapper {
                 "verifyEmail": Object {
                   "verfied": false,
                 },
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "component": [Function],
+                "path": "/ssoLogin/:loginIdp",
               },
               "ref": null,
               "rendered": null,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -103,6 +103,14 @@ export class App extends Component {
             authorization={this.props.authorization}
             verifyEmail={this.props.verifyEmail}
           />
+          <Route
+            path="/ssoLogin/:loginIdp"
+            component={({ match }) => {
+              if (match.params.loginIdp)
+                implicitAuthManager.config.kcIDPHint = match.params.loginIdp;
+              window.location = implicitAuthManager.getSSOLoginURI();
+            }}
+          />
           <Route path="/login" component={LoginRoute} />
           <Route
             path="/logout"


### PR DESCRIPTION
Added a route for rocketchat redirect action.
Flow:
1. rocket chat goes to sso for auth, with a idp specified
2. if user does not meet the requirement, then they are redirected to reggie, with the idp -> this hits the route instead of the login route
